### PR TITLE
Combining junit files drops the file name

### DIFF
--- a/src/PhpunitMerger/Command/LogCommand.php
+++ b/src/PhpunitMerger/Command/LogCommand.php
@@ -95,7 +95,7 @@ class LogCommand extends Command
                 $element->setAttribute('parent', $parent->getAttribute('name'));
                 $attributes = $testSuite['@attributes'] ?? [];
                 foreach ($attributes as $key => $value) {
-                    $value = $key === 'name' ? $value : 0;
+                    $value = $key === 'name' || $key === 'file' ? $value : 0;
                     $element->setAttribute($key, (string)$value);
                 }
                 $parent->appendChild($element);


### PR DESCRIPTION
We were combining two junit files produced by phpunit, but the combined file loses the file name attribute. Then later when we processed with the phpmetrics project, it complained it couldn't find the file named '0';

